### PR TITLE
Add attribution to the bottom right the map

### DIFF
--- a/src/components/HotspotsMap/Attribution.tsx
+++ b/src/components/HotspotsMap/Attribution.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link"
+
+export function Attribution() {
+  return (
+    <div className="absolute bottom-1 right-2.5 z-10">
+      <Link
+        href="https://hotspotty.net"
+        target="_blank"
+        aria-label="Powered by Hotspotty"
+      >
+        <span className="text-xs text-zinc-800 dark:text-zinc-200">
+          Powered by{" "}
+        </span>
+        <span className="text-base font-semibold text-zinc-800 dark:text-white">
+          Hotspotty
+        </span>
+      </Link>
+    </div>
+  )
+}

--- a/src/components/HotspotsMap/index.tsx
+++ b/src/components/HotspotsMap/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import Map, { Layer, MapLayerMouseEvent, MapRef, Source } from "react-map-gl"
+import { Attribution } from "./Attribution"
 import { LayerTabs } from "./LayerTabs"
 import {
   HexFeatureDetails,
@@ -118,12 +119,12 @@ export function HotspotsMap({ children }: { children: React.ReactNode }) {
       cursor={cursor}
       ref={mapRef}
       attributionControl={false}
-      logoPosition="bottom-right"
     >
       {children}
-      <div className="fixed bottom-6 z-10 flex w-full justify-center">
+      <div className="fixed bottom-10 z-10 flex w-full justify-center sm:bottom-6">
         <LayerTabs />
       </div>
+      <Attribution />
       {selectedHex && (
         <Source type="geojson" data={selectedHex.geojson}>
           <Layer type="line" paint={getHexOutlineStyle(resolvedTheme)} />


### PR DESCRIPTION
Similar to [Mapbox's attribution logo](https://docs.mapbox.com/help/getting-started/attribution/), this PR adds a similar attribution to Hotspotty given that the map section is developed and maintained by the Hotspotty team and APIs.

<img width="1798" alt="image" src="https://user-images.githubusercontent.com/3253186/231126361-e845e31b-b8ee-4b7b-ba5f-a44cb4c442cb.png">
