### PR TITLE
Fix 'Learn more about MOBILE' duplication

### DIFF
--- a/src/app/stats/components/index.tsx
+++ b/src/app/stats/components/index.tsx
@@ -92,7 +92,7 @@ const IOT_INFO = {
   title: "IOT",
   activeUrl: "https://iot-rewards.oracle.helium.io/active-devices",
   link: "https://docs.helium.com/lorawan-on-helium",
-  linkText: "Learn More About MOBILE",
+  linkText: "Learn More About IOT",
 }
 
 const SubDaoInfo = ({ sDaoMint }: { sDaoMint: PublicKey }) => {


### PR DESCRIPTION
'Learn more about MOBILE' is duplicated on the stats page. Changed the IOT link to 'Learn more about IOT'.