### PR TITLE
Update the link structure for hotspot details

### DIFF
--- a/src/app/hotspots/[address]/components/HotspotDetails.tsx
+++ b/src/app/hotspots/[address]/components/HotspotDetails.tsx
@@ -13,7 +13,7 @@ export const HotspotDetails = () => {
       <ul className="p-4">
         <li className="flex">
           <Link
-            href={`https://app.hotspotty.net/devices/${address}/status`}
+            href={`https://app.hotspotty.net/hotspots/${address}/rewards`}
             className={clsx(
               "flex gap-2 rounded-xl p-3",
               "border-zinc-900/5 bg-white text-zinc-800 shadow",

--- a/src/components/HotspotsMap/HexHotspots.tsx
+++ b/src/components/HotspotsMap/HexHotspots.tsx
@@ -108,7 +108,7 @@ export async function HexHotspots({ hexId }: { hexId: string }) {
                   <li key={hotspot.hotspot_id}>
                     <div className="group relative flex items-center px-2 py-3">
                       <a
-                        href={`https://app.hotspotty.net/devices/${hotspot.hotspot_id}/status`}
+                        href={`https://app.hotspotty.net/hotspots/${hotspot.hotspot_id}/rewards`}
                         target="_blank"
                         className="-m-1 block flex-1 p-1"
                       >


### PR DESCRIPTION
Hotspotty's new version to support displaying oracle data and many more things in light of the Solana migration is nearly ready. Once it's deployed, the url structure of hotspot details pages will be different. The changes are reflected in this PR.