### PR TITLE
Add supply staked to stats

### DIFF
--- a/src/app/stats/components/HntInfo.tsx
+++ b/src/app/stats/components/HntInfo.tsx
@@ -3,10 +3,17 @@ import { StatsList } from "@/app/stats/components/StatsList"
 import { ONE_DAY_MS, fetcher } from "@/app/stats/utils"
 import { BN } from "@coral-xyz/anchor"
 import { currentEpoch } from "@helium/helium-sub-daos-sdk"
-import { MOBILE_MINT, amountAsNum } from "@helium/spl-utils"
+import {
+  HNT_MINT,
+  MOBILE_MINT,
+  amountAsNum,
+  humanReadable,
+} from "@helium/spl-utils"
 import { format } from "date-fns"
 import { fetchSubDaoEpochInfo } from "../../stats/utils/fetchSubDaoEpochInfo"
 import { fetchUnixTimestap } from "../../stats/utils/fetchUnixTimestamp"
+import { fetchGovernanceStats } from "../utils/fetchGovernanceMetrics"
+import { fetchMint } from "../utils/fetchMint"
 import { Countdown } from "./Countdown"
 
 const COINGECKO_HNT_URL =
@@ -14,10 +21,18 @@ const COINGECKO_HNT_URL =
 const NEXT_HALVENING = 1690848000 // unix time
 
 export const HntInfo = async () => {
-  const [unixTime, hntPrice] = await Promise.all([
+  const [unixTime, hntPrice, hntMint, governanceStats] = await Promise.all([
     fetchUnixTimestap(),
     fetcher(COINGECKO_HNT_URL),
+    fetchMint(HNT_MINT),
+    fetchGovernanceStats(),
   ])
+
+  const hntStakedTotal = governanceStats.network.total.hnt
+  const hntStakedPercent = hntStakedTotal
+    .mul(new BN(10000))
+    .div(new BN(hntMint.info?.info.supply))
+
   const epoch = currentEpoch(new BN(unixTime)).toNumber()
   const epochInfo = await fetchSubDaoEpochInfo(MOBILE_MINT)
   const lastEpochEnd = amountAsNum(epochInfo.info?.rewardsIssuedAt || 0, 0)
@@ -48,6 +63,14 @@ export const HntInfo = async () => {
       <StatItem
         label="Last Epoch Ended"
         value={format(new Date(lastEpochEnd * 1000), "Y/MM/dd HH:mm:ss")}
+      />
+      <StatItem
+        label="Supply Staked"
+        value={`${humanReadable(hntStakedPercent, 2)}%`}
+        tooltip={{
+          description:
+            "Percent of current HNT which is staked as veHNT on Realms",
+        }}
       />
     </StatsList>
   )

--- a/src/app/stats/components/HntInfo.tsx
+++ b/src/app/stats/components/HntInfo.tsx
@@ -49,7 +49,7 @@ export const HntInfo = async () => {
       <StatItem
         label="Price (HNT)"
         value={`$${hntPrice.helium.usd}`}
-        tooltip={{ sourceText: "Coingecko", cadence: "Live" }}
+        tooltip={{ sourceText: "Coingecko", cadence: "Live", id: "HNT Price" }}
       />
       <StatItem
         label="Last Epoch Ended"
@@ -72,6 +72,7 @@ export const HntInfo = async () => {
         tooltip={{
           description: "Current supply of HNT",
           cadence: "Live",
+          id: "HNT Supply",
         }}
       />
       <StatItem
@@ -80,6 +81,7 @@ export const HntInfo = async () => {
         tooltip={{
           description:
             "Percent of current HNT which is staked as veHNT on Realms",
+          id: "HNT Supply Staked",
         }}
       />
     </StatsList>

--- a/src/app/stats/components/HntInfo.tsx
+++ b/src/app/stats/components/HntInfo.tsx
@@ -8,6 +8,7 @@ import {
   MOBILE_MINT,
   amountAsNum,
   humanReadable,
+  humanReadableBigint,
 } from "@helium/spl-utils"
 import { format } from "date-fns"
 import { fetchSubDaoEpochInfo } from "../../stats/utils/fetchSubDaoEpochInfo"
@@ -50,6 +51,10 @@ export const HntInfo = async () => {
         value={`$${hntPrice.helium.usd}`}
         tooltip={{ sourceText: "Coingecko", cadence: "Live" }}
       />
+      <StatItem
+        label="Last Epoch Ended"
+        value={format(new Date(lastEpochEnd * 1000), "Y/MM/dd HH:mm:ss")}
+      />
       <StatItem label="Current Epoch" value={epoch} />
       <StatItem label="Next Epoch In">
         <Countdown date={epoch * ONE_DAY_MS + ONE_DAY_MS} />
@@ -57,12 +62,17 @@ export const HntInfo = async () => {
       <StatItem label="Halvening In">
         <Countdown date={NEXT_HALVENING * 1000} />
       </StatItem>
-      <StatItem label="Landrush Period End">
-        <Countdown date={100} />
-      </StatItem>
       <StatItem
-        label="Last Epoch Ended"
-        value={format(new Date(lastEpochEnd * 1000), "Y/MM/dd HH:mm:ss")}
+        label="Supply"
+        value={humanReadableBigint(
+          hntMint.info?.info.supply,
+          hntMint?.info?.info || 8,
+          0
+        )}
+        tooltip={{
+          description: "Current supply of HNT",
+          cadence: "Live",
+        }}
       />
       <StatItem
         label="Supply Staked"

--- a/src/app/stats/components/StatItem.tsx
+++ b/src/app/stats/components/StatItem.tsx
@@ -41,9 +41,6 @@ export const StatItem = ({
     </p>
   )
 
-  // unit used to differentiate for subDAO specific tooltip description
-  const tooltipId = unit || label
-
   return (
     <div
       className={clsx(
@@ -54,7 +51,7 @@ export const StatItem = ({
     >
       <div className="flex justify-between">
         <p className="text-sm">{label}</p>
-        {!!tooltip && <Tooltip id={tooltipId} {...tooltip} />}
+        {!!tooltip && <Tooltip {...tooltip} />}
       </div>
       {Value}
     </div>

--- a/src/app/stats/components/SudDaoInfo.tsx
+++ b/src/app/stats/components/SudDaoInfo.tsx
@@ -60,6 +60,7 @@ export const SubDaoInfo = async ({ sDaoMint }: { sDaoMint: PublicKey }) => {
         tooltip={{
           description: "Utility score for the most recently completed epoch",
           cadence: "Daily",
+          id: "Utility Score",
         }}
       />
       <StatItem
@@ -68,6 +69,7 @@ export const SubDaoInfo = async ({ sDaoMint }: { sDaoMint: PublicKey }) => {
         tooltip={{
           description: "Hotspots active in past 24h",
           cadence: "Live",
+          id: "Active Hotspots",
         }}
       />
       <StatItem
@@ -76,18 +78,18 @@ export const SubDaoInfo = async ({ sDaoMint }: { sDaoMint: PublicKey }) => {
           epochInfo.info?.vehntAtEpochStart.toString() || "0"
         )}
         tooltip={{
-          description:
-            "veHNT delegated to the subDAO at the start of the most recently completed epoch",
+          description: `veHNT delegated to the ${title} subDAO at the start of the most recently completed epoch`,
           cadence: "Daily",
+          id: `${title} veHNT delegated`,
         }}
       />
       <StatItem
         label="DC Burned (24h)"
         value={humanReadable(epochInfo.info?.dcBurned, 0)}
         tooltip={{
-          description:
-            "DC burned by the subDAO during the most recently completed epoch",
+          description: `DC burned for data transfer by the ${title} subDAO during the most recently completed epoch`,
           cadence: "Daily",
+          id: `${title} DC Burned (24h)`,
         }}
       />
       <StatItem
@@ -98,8 +100,9 @@ export const SubDaoInfo = async ({ sDaoMint }: { sDaoMint: PublicKey }) => {
           0
         )}
         tooltip={{
-          description: "Current funding of the subDAO's treasury",
+          description: `Current funding of ${title}'s treasury`,
           cadence: "Live",
+          id: `${title} Treasury (HNT)`,
         }}
       />
       <StatItem
@@ -110,8 +113,9 @@ export const SubDaoInfo = async ({ sDaoMint }: { sDaoMint: PublicKey }) => {
           0
         )}
         tooltip={{
-          description: "Current supply of the subDAO's token",
+          description: `Current supply of ${title}`,
           cadence: "Live",
+          id: `${title} Supply`,
         }}
       />
       <StatItem
@@ -121,6 +125,7 @@ export const SubDaoInfo = async ({ sDaoMint }: { sDaoMint: PublicKey }) => {
         tooltip={{
           description: `Estimated swap rate for ${title} to HNT. This is a floor that is guaranteed by the treasury. You may find better swap rates on DEXs`,
           cadence: "Daily",
+          id: `${title} Estimated Swap`,
         }}
       />
     </StatsList>

--- a/src/app/stats/components/Tooltip.tsx
+++ b/src/app/stats/components/Tooltip.tsx
@@ -8,13 +8,15 @@ export type ToolTipProps = {
   sourceText?: string
   description?: string
   cadence?: string
-}
-
-type Props = ToolTipProps & {
   id: string
 }
 
-export const Tooltip = ({ id, sourceText, description, cadence }: Props) => {
+export const Tooltip = ({
+  id,
+  sourceText,
+  description,
+  cadence,
+}: ToolTipProps) => {
   return (
     <div>
       <a data-tooltip-id={id} data-tooltip-place="top">


### PR DESCRIPTION
![Screenshot 2023-05-16 at 11 20 06 AM](https://github.com/helium/network-explorer/assets/13353346/2c9361be-ac6e-46f8-b536-09a6e0a52d7d)
![Screenshot 2023-05-16 at 11 19 57 AM](https://github.com/helium/network-explorer/assets/13353346/b9d4b1b8-9a81-4485-86bd-354529053a21)

Also replaces landrush with hnt supply and updates descriptions.
