### PR TITLE
Add daily network usage total

### DIFF
--- a/src/app/stats/components/NetworkUsageGraph.tsx
+++ b/src/app/stats/components/NetworkUsageGraph.tsx
@@ -39,14 +39,13 @@ const CustomTooltip = ({
       >
         <p className="label">Date: {format(label, DATE_FORMAT)}</p>
         {payload.map(({ dataKey, name, value }) => {
-          if (name === "projectedRemaining" && value === 0) return null
-
           let labelFormatted = ""
+
           if (name === "iotUsage") labelFormatted = "IOT usage"
           else if (name === "mobileUsage") labelFormatted = "MOBILE usage"
           else if (name === "rate") labelFormatted = "USD/hour"
           else if (name === "projectedRemaining") {
-            labelFormatted = "Est Daily Total"
+            labelFormatted = value === 0 ? "Daily Total" : "Est Daily Total"
 
             const targetNames = [
               "iotUsage",


### PR DESCRIPTION
Adds daily network usage total. This makes it easier to compare to the current day's estimated total.

![Screenshot 2023-06-27 at 11 32 10 AM](https://github.com/helium/network-explorer/assets/13353346/cef83153-8c80-4413-b17f-6b94c51c7984)
