### PR TITLE
Improve rate labelling

### DIFF
--- a/src/app/stats/components/NetworkUsageGraph.tsx
+++ b/src/app/stats/components/NetworkUsageGraph.tsx
@@ -95,11 +95,11 @@ export const NetworkUsageGraph = ({ data }: NetworkUsageGraphProps) => {
           <YAxis
             tickFormatter={(value) => "$" + (value as number).toFixed(0)}
             yAxisId="USD"
+            orientation="right"
           />
           <YAxis
-            tickFormatter={(value) => "$" + (value as number).toFixed(0)}
+            tickFormatter={(value) => `$${(value as number).toFixed(0)}/h`}
             yAxisId="USD/h"
-            orientation="right"
           />
           <XAxis
             dataKey="date"


### PR DESCRIPTION
- flip y-axes
- properly label rate as $/h

![Screenshot 2023-07-18 at 9 47 53 AM](https://github.com/helium/network-explorer/assets/13353346/6eca57df-8279-422b-b997-766d5fb243c2)
