### PR TITLE
Add API routes for supply stats

### DIFF
--- a/src/app/api/stats/supply/[token]/route.ts
+++ b/src/app/api/stats/supply/[token]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchMint } from "@/app/stats/utils/fetchMint"
+import { HNT_MINT, MOBILE_MINT, IOT_MINT, toNumber } from "@helium/spl-utils"
+import {
+  getRemainingEmissions,
+  MAX_DAILY_NET_EMISSIONS,
+} from "@/app/stats/utils/remainingEmissions"
+
+type SupplyToken = "hnt" | "mobile" | "iot"
+type SupplyType = "circulating" | "total" | "max"
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { token: string } }
+) {
+  const searchParams = request.nextUrl.searchParams
+  const token = params.token as SupplyToken
+  const type = searchParams.get("type") as SupplyType
+
+  if (
+    !["hnt", "mobile", "iot"].includes(token) ||
+    !["circulating", "total", "max"].includes(type)
+  ) {
+    return new NextResponse(null, { status: 400 })
+  }
+
+  const mintInfo = await fetchMint(
+    {
+      hnt: HNT_MINT,
+      mobile: MOBILE_MINT,
+      iot: IOT_MINT,
+    }[token]
+  )
+
+  if (type === "circulating") {
+    const circulatingSupply = mintInfo.info?.info.supply!
+
+    return NextResponse.json(
+      toNumber(circulatingSupply, mintInfo?.info?.info.decimals || 0)
+    )
+  } else if (type === "total" || type === "max") {
+    // Return the same thing for total and max as they are functionally the same for us
+    let remainingEmissions = Math.ceil(getRemainingEmissions(new Date(), token))
+
+    if (token === "hnt") {
+      // Due to Net Emissions, assume the max amount will be re-emitted
+      remainingEmissions += Math.ceil(MAX_DAILY_NET_EMISSIONS)
+    }
+
+    const totalSupply =
+      mintInfo.info?.info.supply! +
+      BigInt(remainingEmissions) *
+        BigInt(Math.pow(10, mintInfo?.info?.info.decimals || 0))
+
+    return NextResponse.json(
+      toNumber(totalSupply, mintInfo?.info?.info.decimals || 0)
+    )
+  }
+}

--- a/src/app/api/stats/supply/[token]/route.ts
+++ b/src/app/api/stats/supply/[token]/route.ts
@@ -3,6 +3,7 @@ import { fetchMint } from "@/app/stats/utils/fetchMint"
 import { HNT_MINT, MOBILE_MINT, IOT_MINT, toNumber } from "@helium/spl-utils"
 import {
   getRemainingEmissions,
+  getDailyEmisisons,
   MAX_DAILY_NET_EMISSIONS,
 } from "@/app/stats/utils/remainingEmissions"
 
@@ -46,6 +47,11 @@ export async function GET(
       // Due to Net Emissions, assume the max amount will be re-emitted
       remainingEmissions += Math.ceil(MAX_DAILY_NET_EMISSIONS)
     }
+
+    // Add the daily emissions for today to be conservative
+    // bc they may or may not have been emitted yet
+    const dailyEmissions = getDailyEmisisons(new Date(), token)
+    remainingEmissions += Math.ceil(dailyEmissions)
 
     const totalSupply =
       mintInfo.info?.info.supply! +

--- a/src/app/stats/components/HntInfo.tsx
+++ b/src/app/stats/components/HntInfo.tsx
@@ -22,12 +22,14 @@ import {
 import { fetchHntGovernanceStats } from "../utils/fetchGovernanceMetrics"
 import { fetchMint } from "../utils/fetchMint"
 import { getNextHalvening } from "../utils/getNextHalvening"
-import { getRemainingEmissions } from "../utils/remainingEmissions"
+import {
+  getRemainingEmissions,
+  MAX_DAILY_NET_EMISSIONS,
+} from "../utils/remainingEmissions"
 import { Countdown } from "./Countdown"
 
 const COINGECKO_HNT_URL =
   "https://api.coingecko.com/api/v3/simple/price?ids=helium&vs_currencies=usd"
-const MAX_DAILY_NET_EMISSIONS = 1643.835616
 const DATE_FORMAT = "M/dd HH:mm OOOO"
 
 export const HntInfo = async () => {

--- a/src/app/stats/utils/remainingEmissions.ts
+++ b/src/app/stats/utils/remainingEmissions.ts
@@ -15,6 +15,8 @@ const YEARLY_EMISSIONS = {
   mobile: 30000000000,
 }
 
+export const MAX_DAILY_NET_EMISSIONS = 1643.835616
+
 type Token = "hnt" | "mobile" | "iot"
 export const getRemainingEmissions = (date: Date, token: Token) => {
   const yearlyEmissions = YEARLY_EMISSIONS[token]


### PR DESCRIPTION
Adds Next API routes for token supply stats at `/api/stats/supply/hnt?type=total` for all 3 tokens and `circulating`, `total` and `max` supply