### PR TITLE
Only use active positions for metrics

### DIFF
--- a/src/app/stats/components/HntInfo.tsx
+++ b/src/app/stats/components/HntInfo.tsx
@@ -23,8 +23,8 @@ import { fetchHntGovernanceStats } from "../utils/fetchGovernanceMetrics"
 import { fetchMint } from "../utils/fetchMint"
 import { getNextHalvening } from "../utils/getNextHalvening"
 import {
-  getRemainingEmissions,
   MAX_DAILY_NET_EMISSIONS,
+  getRemainingEmissions,
 } from "../utils/remainingEmissions"
 import { Countdown } from "./Countdown"
 


### PR DESCRIPTION
Removes fully decayed positions from the governance metrics.