### PR TITLE
Catch-all for all supported HTTP methods

### DIFF
--- a/src/app/[...rest]/page.tsx
+++ b/src/app/[...rest]/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation"
-
-export default function Page() {
-  redirect("/")
-}

--- a/src/app/[...rest]/route.ts
+++ b/src/app/[...rest]/route.ts
@@ -1,0 +1,24 @@
+import { redirect } from "next/navigation"
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  return redirect("/")
+}
+export async function POST() {
+  return new NextResponse(null, { status: 404 })
+}
+export async function PUT() {
+  return new NextResponse(null, { status: 404 })
+}
+export async function PATCH() {
+  return new NextResponse(null, { status: 404 })
+}
+export async function DELETE() {
+  return new NextResponse(null, { status: 404 })
+}
+export async function HEAD() {
+  return new NextResponse(null, { status: 404 })
+}
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 404 })
+}


### PR DESCRIPTION
We are getting errors from people trying to probe our website for unsupported routes. Adding all supported HTTP methods to catch-all and return 404.