### PR TITLE
Calculate total emissions server side

### DIFF
--- a/src/app/stats/components/HntEmissions.tsx
+++ b/src/app/stats/components/HntEmissions.tsx
@@ -8,10 +8,10 @@ export const HntEmissions = async () => {
   const { totalEmissions, subDaoEmissions } = await fetchHntEmissions()
 
   const hntEmissionsData: { [date: string]: HntEmissionRow } = {}
-  totalEmissions.result.rows.forEach(({ block_date, hnt_minted }) => {
+  totalEmissions.forEach(({ block_date, hnt_minted }) => {
     hntEmissionsData[block_date] = {
       date: block_date,
-      total: parseInt(hnt_minted, 10),
+      total: hnt_minted,
       iot: 0,
       mobile: 0,
     }
@@ -49,9 +49,7 @@ export const HntEmissions = async () => {
             HNT Emissions History (30 days)
             <Tooltip
               id="hnt-emissions"
-              description={`Last fetched: Total: ${formatDuneDate(
-                totalEmissions.execution_started_at
-              )} --- Treasury: ${formatDuneDate(
+              description={`Last fetched: ${formatDuneDate(
                 subDaoEmissions.execution_started_at
               )}`}
               cadence="Daily"

--- a/src/app/stats/components/HntInfo.tsx
+++ b/src/app/stats/components/HntInfo.tsx
@@ -156,10 +156,7 @@ export const HntInfo = async () => {
       />
       <StatItem
         label="Latest Emission"
-        value={numberWithCommas(
-          parseInt(hntEmissions.totalEmissions.result.rows[0].hnt_minted, 10),
-          0
-        )}
+        value={numberWithCommas(hntEmissions.totalEmissions[0].hnt_minted, 0)}
         tooltip={{
           description: `Amount of HNT emitted last epoch.`,
           cadence: "Daily",


### PR DESCRIPTION
The query we had for total issuance was regularly messing up for the most recent day (see below) despite having the requisite data. Decided to get the total on our back-end by replacing the buggy query with an HST query (we already have the subDAO treasury emissions query setup and playing nice).
![Screenshot 2024-02-16 at 1 02 50 PM](https://github.com/helium/network-explorer/assets/13353346/b558f401-729f-4b28-b95d-83ed6dd6dc66)
